### PR TITLE
FIT-5: Prevent User from adding duplicate exercises

### DIFF
--- a/FitnessApp/App.tsx
+++ b/FitnessApp/App.tsx
@@ -34,6 +34,7 @@ export type RootStackParamList = {
     category: ExerciseCategory;
     route: RouteProp<RootStackParamList, 'ChooseExerciseFromCategory'>;
     updateRoutineExercises?: (newExercise: Exercise) => void;
+    routineExercises?: Exercise[];
     currWorkoutSession?: WorkoutSession,
     goBackToPreviousScreen: () => void;
     goBackToCurrentWorkout?: (currWorkoutSession: WorkoutSession) => void;
@@ -42,6 +43,7 @@ export type RootStackParamList = {
   SelectExerciseStack: {
     currWorkoutSession?: WorkoutSession; // Optional WorkoutSession prop
     updateRoutineExercises?: (newExercise: Exercise) => void;
+    routineExercises?: Exercise[];
   },
 
   ViewRoutine: undefined,   //Lists all routines saved by the user for them to choose from

--- a/FitnessApp/src/screens/CreateRoutine.tsx
+++ b/FitnessApp/src/screens/CreateRoutine.tsx
@@ -12,8 +12,8 @@ const CreateRoutine = ({ navigation }: Props) => {
 
   //Callback function to update routineExercises
   const updateRoutineExercises = (newExercise: Exercise) => {
-      setExercises([...exercises, newExercise]);
-    };
+    setExercises([...exercises, newExercise]); 
+  }
 
   //Saves the current routine
   const handleSaveRoutine = async () => {
@@ -45,6 +45,7 @@ const CreateRoutine = ({ navigation }: Props) => {
 
   const handleSelectExercise = () => {
     navigation.navigate('SelectExerciseStack', {
+      routineExercises: exercises,
       updateRoutineExercises,
     });
   };

--- a/FitnessApp/src/screens/CurrentWorkoutSession.tsx
+++ b/FitnessApp/src/screens/CurrentWorkoutSession.tsx
@@ -23,7 +23,7 @@ type CurrentWorkoutSessionProps = {
 const CurrentWorkoutSession = ({ route, navigation }: CurrentWorkoutSessionProps) => {
 
   //1) Screen Attributes
-  const { routine, currWorkoutSession } = route.params;
+  const { currWorkoutSession } = route.params;
   const initialWorkoutSession = currWorkoutSession ? currWorkoutSession : createWorkoutSession(route.params?.routine as Routine); 
   const [routineLoaded, setRoutineLoaded] = useState<boolean>(false);
 

--- a/FitnessApp/src/screens/ScreenStacks/SelectExerciseStack.tsx
+++ b/FitnessApp/src/screens/ScreenStacks/SelectExerciseStack.tsx
@@ -7,12 +7,14 @@ import { RouteProp, useRoute } from '@react-navigation/native';
 import { WorkoutSession } from '../../Components/WorkoutSession';
 import { Exercise } from '../../Components/Exercise';
 import CreateExercise from '../CreateExercise';
+import { Routine } from '../../Components/AppComponents';
 
 //Create Stack Navigator
 const Stack = createStackNavigator<RootStackParamList>();
 
 export type SelectExerciseCategoryParams = {
   updateRoutineExercises?: (newExercise: Exercise) => void;
+  routineExercises?: Exercise[];
   updateWorkoutSessionExercises?: (newExercise: Exercise) => void;
   currWorkoutSession?: WorkoutSession;
 };
@@ -26,6 +28,7 @@ const SelectExerciseStack = () => {
   // Access the updateRoutineExercises function  or the currWorkoutSession from the route parameter (if defined)
   const currWorkoutSession = route.params?.currWorkoutSession;
   const updateRoutineExercises = route.params?.updateRoutineExercises;
+  const routineExercises = route.params?.routineExercises;
 
   //Determine which optional parameter was defined and which wasn't
   // Create an object for initial parameters
@@ -37,12 +40,13 @@ const SelectExerciseStack = () => {
 
   if (updateRoutineExercises) {
     params.updateRoutineExercises = updateRoutineExercises;
+    params.routineExercises = routineExercises;
   }
   
   return (
     <Stack.Navigator>
       <Stack.Screen name="SelectExerciseCategory" component={SelectExerciseCategory} 
-        initialParams={{ currWorkoutSession, updateRoutineExercises } as SelectExerciseCategoryParams}  options={{ headerShown: false }}/>
+        initialParams={{ currWorkoutSession, updateRoutineExercises, routineExercises } as SelectExerciseCategoryParams}  options={{ headerShown: false }}/>
       <Stack.Screen name="ChooseExerciseFromCategory" component={ChooseExerciseFromCategory} options={{ headerShown: false }} />
       <Stack.Screen name="CreateExercise" component={CreateExercise} options={{ headerShown: false }} />
     </Stack.Navigator>

--- a/FitnessApp/src/screens/SelectExerciseCategory.tsx
+++ b/FitnessApp/src/screens/SelectExerciseCategory.tsx
@@ -1,14 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, FlatList, Animated } from 'react-native';
 import { styles } from '../Misc/ComponentStyles';
-import {Exercise } from '../Components/Exercise';
-import {ExerciseCategory, loadExerciseCategories } from '../Components/ExerciseCategory';
+import { Exercise } from '../Components/Exercise';
+import { Routine } from '../Components/AppComponents';
+import { ExerciseCategory, loadExerciseCategories } from '../Components/ExerciseCategory';
 import { WorkoutSession } from '../Components/WorkoutSession';
 
 type SelectCategoryProps = {
   navigation: any; // The navigation prop used for screen navigation
   route: {
     params: {
+      routineExercises?: Exercise[];
       updateRoutineExercises?: (newExercise: Exercise) => void; // Callback function to update routineExercises
       currWorkoutSession?: WorkoutSession;
     };
@@ -19,7 +21,7 @@ const SelectExerciseCategory = ({ route, navigation }: SelectCategoryProps) => {
 
     //List of saved exercise categories
     const [categories, setCategories] = useState<ExerciseCategory[]>([]);
-    const { currWorkoutSession, updateRoutineExercises } = route.params;
+    const { currWorkoutSession, updateRoutineExercises, routineExercises } = route.params;
 
     //Loads all existing ExerciseCategory objects upon loading page
     useEffect(() => {
@@ -46,10 +48,14 @@ const SelectExerciseCategory = ({ route, navigation }: SelectCategoryProps) => {
     };
     
     const handleAddExerciseToRoutine = (category: ExerciseCategory) => {
+      console.log('HERE1')
       if(updateRoutineExercises){
+        console.log('KATAKURIBALLZ')
+        console.log(routineExercises)
         navigation.navigate('ChooseExerciseFromCategory', {
           category: category,
           updateRoutineExercises: updateRoutineExercises,
+          routineExercises: routineExercises,
           goBackToPreviousScreen: goBackToCreateRoutine
         });
       }


### PR DESCRIPTION
- Added validation in ChooseExerciseFromCategory to prevent user from adding an exercise that is already present in the session
- Added validation in ChooseExerciseFromCategory to prevent user from adding an exercise already present in the current routine creation (cannot pass routine object as it is not yet created at that state, passes the current list of exercises directly instead)
- Added routineExercises optional parameter to SelectExerciseStack, SelectExerciseCategory and ChooseExerciseFromCategory to facilitate this new validation during the creation of a routine